### PR TITLE
return the server error in case of overloading

### DIFF
--- a/src/main/java/com/proxy/server/directives/DirectiveUtils.java
+++ b/src/main/java/com/proxy/server/directives/DirectiveUtils.java
@@ -3,28 +3,30 @@ package com.proxy.server.directives;
 import akka.NotUsed;
 import akka.http.javadsl.common.EntityStreamingSupport;
 import akka.http.javadsl.common.JsonEntityStreamingSupport;
-import akka.http.javadsl.marshallers.jackson.Jackson;
-import akka.http.javadsl.model.HttpEntity;
 import akka.http.javadsl.model.HttpResponse;
-import akka.http.javadsl.model.MediaType;
-import akka.http.javadsl.model.MediaTypes;
 import akka.http.javadsl.model.StatusCodes;
-import akka.http.javadsl.unmarshalling.Unmarshaller;
 import akka.stream.javadsl.Flow;
 import akka.util.ByteString;
-import io.vavr.collection.HashSet;
 import io.vavr.collection.Set;
 
 public class DirectiveUtils {
-    /**
-     * "Accepted", "The request has been accepted for processing, but the processing has not been completed. 
-     * */
-    public static HttpResponse ACCEPTED = HttpResponse.create().withStatus(StatusCodes.ACCEPTED);
+    public static String SERVER_OVERLOADED_MESSAGE = "Sorry! something went wrong. Please try later";
+    public static String INVALID_NUMBERS_MESSAGE = "The prime numbers are not defined for numbers lower than 2";
+    public static String INVALID_INPUT_MESSAGE = "The input should be an integer number between 2 and 2147483647";
     
     /**
      * "Bad Request", "The request contains bad syntax or cannot be fulfilled.
      */
-    public static HttpResponse BAD_REQUEST = HttpResponse.create().withStatus(StatusCodes.BAD_REQUEST);
+    public static HttpResponse BAD_REQUEST = HttpResponse.create()
+        .withStatus(StatusCodes.BAD_REQUEST)
+        .withEntity(INVALID_INPUT_MESSAGE);
+    
+    /**
+     * "Bad Request", "The request contains bad syntax or cannot be fulfilled.
+     */
+    public static HttpResponse SERVER_OVERLOADED = HttpResponse.create()
+        .withStatus(StatusCodes.INTERNAL_SERVER_ERROR)
+        .withEntity(SERVER_OVERLOADED_MESSAGE);
     
     /**
      *  Returns 404 response with a body including the validation error

--- a/src/main/java/com/proxy/server/directives/NumbersRoute.java
+++ b/src/main/java/com/proxy/server/directives/NumbersRoute.java
@@ -37,12 +37,11 @@ public class NumbersRoute extends AllDirectives {
                 
                 Tuple2<Option<String>, Source<Integer, NotUsed>> response = client.readItem(number);
                 if(response._1().isDefined()) {
-                    return complete(HttpResponse.create()
-                        .withStatus(StatusCodes.BAD_REQUEST)
-                        .withEntity(response._1().get()));
+                    return complete(response._1().get().equals(DirectiveUtils.SERVER_OVERLOADED_MESSAGE) ?
+                        DirectiveUtils.SERVER_OVERLOADED :
+                        DirectiveUtils.BAD_REQUEST);
                 } else {
                     Source<ByteString, NotUsed> map = response._2().map(i -> ByteString.fromString(i.toString()));
-                    
                     return completeOKWithSource(map, Marshaller.byteStringMarshaller(ContentTypes.APPLICATION_JSON), EntityStreamingSupport.json()
                         .withContentType(ContentTypes.APPLICATION_JSON)
                         .withParallelMarshalling(10, false));

--- a/src/main/java/com/proxy/server/primenumbersserver/PrimeNumbersProtocol.java
+++ b/src/main/java/com/proxy/server/primenumbersserver/PrimeNumbersProtocol.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 import com.primenumbers.server.grpc.PrimeNumbersResponse;
 import com.primenumbers.server.grpc.PrimeNumbersServiceClient;
 import com.primenumbers.server.grpc.ReadNumbersRequest;
+import com.proxy.server.directives.DirectiveUtils;
 
 import akka.NotUsed;
 import akka.stream.Materializer;
@@ -47,7 +48,7 @@ public class PrimeNumbersProtocol {
             firstElement = source.take(1).runWith(Sink.head(), materializer)
                 .toCompletableFuture().get(10, TimeUnit.SECONDS); // If we don't receive the first element in 10 seconds, we will return the server error
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
-            return Tuple.of(Option.of("Server Error!"), Source.empty());
+            return Tuple.of(Option.of(DirectiveUtils.SERVER_OVERLOADED_MESSAGE), Source.empty());
         }
         
         // Read the first item and then reply based on that.. either an error or the 


### PR DESCRIPTION
If server is overloaded and we cannot return the beginning of a stream in 10 seconds,
then we need to return server error.